### PR TITLE
Add new custom lastaccess date filter for teacher dashboard.

### DIFF
--- a/classes/local/entities/userenrolment.php
+++ b/classes/local/entities/userenrolment.php
@@ -25,6 +25,7 @@ use core_reportbuilder\local\report\column;
 use core_reportbuilder\local\report\filter;
 use core_reportbuilder\local\entities\base;
 use core_reportbuilder\local\helpers\format;
+use local_ace\local\filters\acedate;
 use local_ace\local\filters\pagecontextcourse;
 use local_ace\local\filters\myenrolledcourses;
 
@@ -156,6 +157,7 @@ class userenrolment extends base {
             new lang_string('role', 'local_ace'),
             $this->get_entity_name()
         ))
+            ->add_joins($this->get_joins())
             ->add_join("JOIN {role} {$rolealias} ON {$rolealias}.id = {$enrolalias}.roleid")
             ->set_is_sortable(true)
             ->add_fields("$rolealias.shortname");
@@ -165,6 +167,7 @@ class userenrolment extends base {
             new lang_string('lastaccessed', 'local_ace'),
             $this->get_entity_name()
         ))
+            ->add_joins($this->get_joins())
             ->add_join("LEFT JOIN {user_lastaccess} {$userlastaccessalias}
                         ON {$userlastaccessalias}.userid = {$userenrolmentsalias}.id
                         AND {$enrolalias}.courseid = {$userlastaccessalias}.courseid")
@@ -249,9 +252,9 @@ class userenrolment extends base {
 
         // User last access (join with mdl_user_lastaccess table).
         $filters[] = (new filter(
-            text::class,
+            acedate::class,
             'lastaccess',
-            new lang_string('lastaccessed', 'local_ace'),
+            new lang_string('lastaccessedtocourse', 'local_ace'),
             $this->get_entity_name(),
             "{$userlastaccessalias}.timeaccess"
         ))

--- a/classes/local/filters/acedate.php
+++ b/classes/local/filters/acedate.php
@@ -1,0 +1,143 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+declare(strict_types=1);
+
+namespace local_ace\local\filters;
+
+use lang_string;
+use MoodleQuickForm;
+use core_reportbuilder\local\helpers\database;
+use core_reportbuilder\local\filters\base;
+
+/**
+ * Ace last access date filter - based on core date filter.
+ *
+ * This filter accepts a unix timestamp to perform date filtering on
+ *
+ * @package     local_ace
+ * @copyright   2021 Canterbury University
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class acedate extends base {
+
+    /** @var int Any value */
+    public const DATE_ANY = 0;
+
+    /** @var int Non-empty (positive) value */
+    public const DATE_NOT_EMPTY = 1;
+
+    /** @var int Empty (zero) value */
+    public const DATE_EMPTY = 2;
+
+    /** @var int Not accessed since  */
+    public const DATE_NOTSINCE = 3;
+
+    /** @var int Relative date unit for a day */
+    public const DATE_UNIT_DAY = 1;
+
+    /** @var int Relative date unit for a week */
+    public const DATE_UNIT_WEEK = 2;
+
+    /** @var int Relative date unit for a month */
+    public const DATE_UNIT_MONTH = 3;
+
+    /** @var int Relative date unit for a month */
+    public const DATE_UNIT_YEAR = 4;
+
+    /**
+     * Return an array of operators available for this filter
+     *
+     * @return lang_string[]
+     */
+    private function get_operators(): array {
+        $operators = [
+            self::DATE_ANY => new lang_string('filterisanyvalue', 'core_reportbuilder'),
+            self::DATE_NOT_EMPTY => new lang_string('filterisnotempty', 'core_reportbuilder'),
+            self::DATE_EMPTY => new lang_string('filterisempty', 'core_reportbuilder'),
+            self::DATE_NOTSINCE => new lang_string('filternotsince', 'local_ace'),
+        ];
+
+        return $this->filter->restrict_limited_operators($operators);
+    }
+
+    /**
+     * Setup form
+     *
+     * @param MoodleQuickForm $mform
+     */
+    public function setup_form(MoodleQuickForm $mform): void {
+        // Operator selector.
+
+        $mform->addElement('select', "{$this->name}_operator", '', $this->get_operators());
+        $mform->setType("{$this->name}_operator", PARAM_INT);
+        $mform->setDefault("{$this->name}_operator", self::DATE_ANY);
+
+        // Date selectors for range operator.
+        $mform->addElement('date_selector', "{$this->name}_to", get_string('date'),
+            ['optional' => true]);
+        $mform->setType("{$this->name}_to", PARAM_INT);
+        $mform->setDefault("{$this->name}_to", 0);
+        $mform->hideIf("{$this->name}_to", "{$this->name}_operator", 'neq', self::DATE_NOTSINCE);
+    }
+
+    /**
+     * Return filter SQL
+     *
+     * @param array $values
+     * @return array
+     */
+    public function get_sql_filter(array $values): array {
+        $fieldsql = $this->filter->get_field_sql();
+        $params = $this->filter->get_field_params();
+
+        $operator = (int) ($values["{$this->name}_operator"] ?? self::DATE_ANY);
+
+        switch ($operator) {
+            case self::DATE_NOT_EMPTY:
+                $sql = "{$fieldsql} IS NOT NULL AND {$fieldsql} <> 0";
+                break;
+            case self::DATE_EMPTY:
+                $sql = "{$fieldsql} IS NULL OR {$fieldsql} = 0";
+                break;
+            case self::DATE_NOTSINCE:
+                $clauses = [];
+
+                $datefrom = (int)($values["{$this->name}_from"] ?? 0);
+                if ($datefrom > 0) {
+                    $paramdatefrom = database::generate_param_name();
+                    $clauses[] = "{$fieldsql} >= :{$paramdatefrom}";
+                    $params[$paramdatefrom] = $datefrom;
+                }
+
+                $dateto = (int)($values["{$this->name}_to"] ?? 0);
+                if ($dateto > 0) {
+                    $paramdateto = database::generate_param_name();
+                    $clauses[] = "({$fieldsql} > :{$paramdateto} OR {$fieldsql} IS NULL OR {$fieldsql} = 0)";
+                    $params[$paramdateto] = $dateto;
+                }
+
+                $sql = implode(' AND ', $clauses);
+
+                break;
+            default:
+                // Invalid or inactive filter.
+                return ['', []];
+        }
+
+        return [$sql, $params];
+    }
+}

--- a/classes/reportbuilder/datasource/users.php
+++ b/classes/reportbuilder/datasource/users.php
@@ -125,6 +125,18 @@ class users extends datasource {
         $this->add_conditions_from_entity($courseentity->get_entity_name());
         $this->add_conditions_from_entity($acesamplesentity->get_entity_name());
         $this->add_conditions_from_entity($coursemodulesentity->get_entity_name());
+
+        // Set default filter if not active - sets the default userenrolment filter to before 7days ago.
+        $filtervalues = $this->get_filter_values();
+        if (empty($filtervalues)) {
+            $lastmidnight = usergetmidnight(time());
+            $days7 = $lastmidnight - WEEKSECS;
+            $defaultfilter['userenrolment:lastaccess_operator'] = 3;
+            $defaultfilter['userenrolment:lastaccess_value'] = 1;
+            $defaultfilter['userenrolment:lastaccess_unit'] = 1;
+            $defaultfilter['userenrolment:lastaccess_to'] = $days7;
+            $this->set_filter_values($defaultfilter);
+        }
     }
 
     /**

--- a/lang/en/local_ace.php
+++ b/lang/en/local_ace.php
@@ -130,3 +130,4 @@ $string['endtime'] = 'End time';
 $string['userentitytitle'] = 'Users';
 $string['totalviews']  = 'All user views';
 $string['totalviewsuser']  = 'Total views';
+$string['filternotsince'] = 'Not since';


### PR DESCRIPTION
this adds a new ace date filter type which allows a single date to be specified - it allows the user to see all users in the report that have not visited the page since the date specified - eg all users that haven't visited the course in the last 7 days. It also defaults that filter when not set by the user to 7 days ago.