### PR TITLE
Replace incorrect usage of min() function

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -922,7 +922,7 @@ function local_ace_course_module_engagement_data(int $cmid, ?int $start = null, 
  * @return float
  */
 function local_ace_normalise_value(float $value, float $min, float $max) {
-    return min((($value - $min) / ($max - $min)) * 100, $max);
+    return min((($value - $min) / ($max - $min)) * 100, 100);
 }
 
 /**


### PR DESCRIPTION
This assumed '$max' would always be 100, in cases where it isn't all values on the page were capped at '$max' which could be any value