### PR TITLE
Add new user count columns to table.

### DIFF
--- a/lang/en/local_ace.php
+++ b/lang/en/local_ace.php
@@ -165,3 +165,5 @@ $string['pagecontextactivity'] = 'Page activity context';
 $string['totalaccesses'] = 'No. of accesses';
 $string['lastaccessanyuser'] = 'Last access by any user';
 $string['lastaccessthisuser'] = 'Last access by this user';
+$string['countallusers'] = 'Number of users who have accessed this activity';
+$string['countallstudents'] = 'Number of students who have accessed this activity';


### PR DESCRIPTION
this is step 1 of this new column - we don't need the basic user count column but I included it for better readability of the bigger query in the student count access version of the same column.

Next step from this is to turn the count into a percentage of enrolled students that have accessed the activity which I thought I'd do separately to help make it slightly easier to PR too.